### PR TITLE
Add Timber compatibility bridge, harden Shadow taxonomy and taxonomy handling, fix PostInterface/Post bug, and add tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,13 @@
       "composer/installers": true
     }
   },
+  "scripts": {
+    "test": [
+      "php tests/unit/taxonomy_create_term_test.php",
+      "php tests/integration/shadow_relationship_test.php",
+      "php tests/e2e/postinterface_search_null_test.php"
+    ]
+  },
   "repositories": [
     {
       "type": "composer",

--- a/library/Post.php
+++ b/library/Post.php
@@ -27,7 +27,7 @@ class Post {
 				'post_author'    => ! empty( $meta['post_author'] ) ? $meta['post_author'] : 1,
 				'post_title'     => ucwords( $title ),
 				'post_name'      => ! empty( $meta['slug'] ) ? sanitize_title( $meta['slug'] ) : sanitize_title( $title ),
-				'post_status'    => ! empty( $meta['post_status'] ) ? $meta['status'] : 'publish',
+				'post_status'    => ! empty( $meta['post_status'] ) ? $meta['post_status'] : 'publish',
 				'post_content'   => $content,
 				'post_type'      => $type,
 				'post_parent'    => $parent,

--- a/library/PostInterface.php
+++ b/library/PostInterface.php
@@ -371,7 +371,11 @@ class PostInterface
                 if (method_exists($search, 'PostInterface_get')) {
                     return $search->PostInterface_get($this->query_args);
                 }
-                $post = $search->search("", $this->query_args)->posts[0];
+                $results = $search->search("", $this->query_args);
+                if (empty($results->posts) || empty($results->posts[0])) {
+                    return null;
+                }
+                $post = $results->posts[0];
             } else {
                 $query = new WP_Query($this->query_args);
                 if (!$query->have_posts()) {
@@ -569,7 +573,7 @@ class TaxonomyHandler
     public function __isset($taxonomy)
     {
         if(empty($this->taxonomies)) {
-            return null;
+            return false;
         }
         return in_array($taxonomy, $this->taxonomies);
     }
@@ -617,7 +621,7 @@ class TaxonomyHandler
         $taxonomy_data = [];
         foreach ($this->taxonomies as $taxonomy) {
             $terms = get_the_terms($this->post_id, $taxonomy);
-            $taxonomy_data[$taxonomy] = $terms ?: [];
+            $taxonomy_data[$taxonomy] = (is_array($terms) && !is_wp_error($terms)) ? $terms : [];
         }
         return $taxonomy_data;
     }

--- a/library/Shadow.php
+++ b/library/Shadow.php
@@ -173,6 +173,13 @@ use WP_Term;
 class Shadow
 {
     /**
+     * Prevent duplicate hook registration.
+     *
+     * @var array<string, bool>
+     */
+    private static array $relationships = [];
+
+    /**
      * Registers the shadow taxonomy relationship and hooks.
      *
      * @param string $post_type    Post Type slug.
@@ -181,6 +188,12 @@ class Shadow
      */
     public static function create_relationship(string $post_type, string $taxonomy, array $conditionals = []): void
     {
+        $key = $post_type . '|' . $taxonomy . '|' . md5(wp_json_encode($conditionals));
+        if (!empty(self::$relationships[$key])) {
+            return;
+        }
+        self::$relationships[$key] = true;
+
         add_action('wp_insert_post', self::create_shadow_term($post_type, $taxonomy, $conditionals));
         add_action('set_object_terms', self::create_shadow_term($post_type, $taxonomy, $conditionals));
         add_action('wp_trash_post', self::delete_shadow_term($taxonomy));
@@ -306,6 +319,9 @@ class Shadow
     {
         return function ($post_id) use ($taxonomy) {
             $post = get_post($post_id);
+            if (!$post instanceof WP_Post) {
+                return false;
+            }
             $term_id = self::get_associated_term_id($post);
 
             if (!$term_id) {
@@ -331,10 +347,15 @@ class Shadow
 
             if (empty($other_posts)) {
                 // No other posts associated, safe to delete term
+                delete_term_meta((int)$term_id, 'shadow_post_id');
                 return wp_delete_term($term_id, $taxonomy);
             } else {
                 // Remove the association from the deleted post
                 delete_post_meta($post_id, 'shadow_term_id');
+                $next_post_id = (int)$other_posts[0];
+                if ($next_post_id > 0) {
+                    update_term_meta((int)$term_id, 'shadow_post_id', $next_post_id);
+                }
                 return false;
             }
         };
@@ -368,7 +389,13 @@ class Shadow
 
         if (empty($other_posts)) {
             // No other posts associated, safe to delete term
+            delete_term_meta($term_id, 'shadow_post_id');
             wp_delete_term($term_id, $taxonomy);
+        } else {
+            $next_post_id = (int)$other_posts[0];
+            if ($next_post_id > 0) {
+                update_term_meta($term_id, 'shadow_post_id', $next_post_id);
+            }
         }
 
         // Remove the association from the post
@@ -400,6 +427,7 @@ class Shadow
 
         // Associate the term with the post
         update_post_meta($post->ID, 'shadow_term_id', $term_id);
+        update_term_meta((int)$term_id, 'shadow_post_id', $post->ID);
 
         return ['term_id' => $term_id];
     }
@@ -446,8 +474,11 @@ class Shadow
      *
      * @return int|false The term ID on success, false on failure.
      */
-    public static function get_associated_term_id(WP_Post $post): bool|int
+    public static function get_associated_term_id($post): bool|int
     {
+        if (!$post instanceof WP_Post) {
+            return false;
+        }
         return get_post_meta($post->ID, 'shadow_term_id', true) ?: false;
     }
 
@@ -474,6 +505,39 @@ class Shadow
 
         $posts = get_posts($args);
         return !empty($posts) ? $posts : false;
+    }
+
+    /**
+     * Gets the post associated with a shadow taxonomy term.
+     *
+     * @param WP_Term|int $term Term object or term ID.
+     *
+     * @return WP_Post|false
+     */
+    public static function get_associated_post($term): WP_Post|bool
+    {
+        if (is_int($term)) {
+            $term = get_term($term);
+        }
+
+        if (!$term instanceof WP_Term) {
+            return false;
+        }
+
+        $post_id = (int)get_term_meta($term->term_id, 'shadow_post_id', true);
+        if ($post_id > 0) {
+            $post = get_post($post_id);
+            if ($post instanceof WP_Post) {
+                return $post;
+            }
+        }
+
+        $associated_posts = self::get_associated_posts($term);
+        if (!empty($associated_posts[0]) && $associated_posts[0] instanceof WP_Post) {
+            return $associated_posts[0];
+        }
+
+        return false;
     }
 
     /**

--- a/library/Taxonomy.php
+++ b/library/Taxonomy.php
@@ -89,7 +89,7 @@ class Taxonomy
         }
 
         if (!(Utility::IsTrue($options['hierarchical']))) {
-            array_shift($options);
+            unset($options['hierarchical']);
         }
         add_action('init', function () use ($tax_name_plural, $tax_machine_name, $post_types, $options) {
             if (!taxonomy_exists($tax_machine_name)) {
@@ -207,24 +207,16 @@ class Taxonomy
         $taxonomy = strtolower(str_replace(" ", "_", $taxonomy));
 
         if (is_array($term)) {
-            //Log::Write($config, 'C:');
             foreach ($term as $k => $v) {
-                //Log::Write($k, 'K:');
-                //Log::Write($v, 'V:');
-                switch ($v) {
-                    case is_array($v):
-                        //Log::Write("Mode: Array\nK:  $k \nV: $v\n");
-                        if (is_int($k)) {
-                            self::CreateTerm($taxonomy, $v, $parent_term);
-                        } else {
-                            self::CreateTerm($taxonomy, $k, $parent_term);
-                            self::CreateTerm($taxonomy, $v, $k);
-                        }
-                        break;
-                    case is_string($v);
-                        //Log::Write("Mode: String\nK:  $k \nV: $v\n");
+                if (is_array($v)) {
+                    if (is_int($k)) {
                         self::CreateTerm($taxonomy, $v, $parent_term);
-                        break;
+                    } else {
+                        self::CreateTerm($taxonomy, $k, $parent_term);
+                        self::CreateTerm($taxonomy, $v, $k);
+                    }
+                } elseif (is_string($v) || is_numeric($v)) {
+                    self::CreateTerm($taxonomy, (string)$v, $parent_term);
                 }
             }
             return true;

--- a/library/Template.php
+++ b/library/Template.php
@@ -2,7 +2,6 @@
 
 namespace WDK;
 
-use Timber\Post;
 use Timber\Timber;
 use Twig\TwigFunction;
 
@@ -98,6 +97,7 @@ class Template
     public static function get_template($predefined_template = null): mixed
     {
         global $post;
+        $post_id = (!empty($post) && !empty($post->ID)) ? (int)$post->ID : null;
 
         if (preg_match('~(\.css|\.js|\.map|\.pdf|\.png|\.jpg|\.gif|.ttf|\.doc|\.xls|\.ico|\.woff2|\.woff|\.svg|admin-ajax.php)~', $_SERVER['REQUEST_URI'])) {
             return false;
@@ -114,7 +114,7 @@ class Template
                 if (defined('WP_DEBUG') && WP_DEBUG) Utility::Log("Checking template for {$base}");
 
                 $template_check_key = "wdk_process_template_{$base}";
-                $template_check = self::get_config_value($template_check_key, $post->ID);
+                $template_check = self::get_config_value($template_check_key, $post_id);
 
                 if (!Utility::IsTrue($template_check)) {
                     if ($template_check !== false) {
@@ -128,7 +128,7 @@ class Template
                 switch ($base) {
                     case 'home':
                         $post_type_key = "wdk_process_template_cpt_home";
-                        $post_type_template = self::get_config_value($post_type_key, $post->ID);
+                        $post_type_template = self::get_config_value($post_type_key, $post_id);
                         $template = ["index.twig", $template, "{$base}.twig"];
                         if (!empty($post_type_template)) {
                             $template = is_bool($post_type_template) ? self::handle_single($post, $template, $base) : $post_type_template;
@@ -138,7 +138,7 @@ class Template
                         break;
                     case 'single':
                         $post_type_key = "wdk_process_template_cpt_{$post->post_type}";
-                        $post_type_template = self::get_config_value($post_type_key, $post->ID);
+                        $post_type_template = self::get_config_value($post_type_key, $post_id);
                         if (!empty($post_type_template)) {
                             $template = is_bool($post_type_template) ? self::handle_single($post, $template, $base) : $post_type_template;
                         } else {
@@ -148,7 +148,7 @@ class Template
 
                     case 'page':
                         $page_template_key = "wdk_process_template_page_{$post->post_name}";
-                        $page_template = self::get_config_value($page_template_key, $post->ID);
+                        $page_template = self::get_config_value($page_template_key, $post_id);
                         $template = $page_template ?: $template;
                         $template = self::handle_page($post, $template, $base);
                         break;
@@ -192,12 +192,12 @@ class Template
      */
     public static function Setup($locations = [__DIR__ . '/views'])
     {
-        Timber::$locations = $locations;
+        TimberBridge::set_locations($locations);
         if (class_exists(Timber::class)) {
             add_filter('timber/context', static function () {
                 $show_templates = self::get_config_value('wdk_debug_show_templates');
                 if (defined('WP_DEBUG') && WP_DEBUG) Utility::Log('inside context hook');
-                $context = Timber::context();
+                $context = TimberBridge::context();
                 $context['page-template'] = $templates = self::get_template();
                 if (defined('WP_DEBUG') && WP_DEBUG) Utility::Log(empty($context['post']));
                 if (!empty($context['posts']) && $context['posts'] instanceof \Timber\PostQuery) {
@@ -220,7 +220,7 @@ class Template
                     }
                 }
 
-                $context['post'] = new Post();
+                $context['post'] = TimberBridge::get_post();
                 if (defined('WP_DEBUG') && WP_DEBUG || $show_templates) {
                     $context_hooks = [];
                 }
@@ -242,10 +242,10 @@ class Template
             });
 
             add_filter('template_include', function ($template) {
-                $context = Timber::context();
+                $context = TimberBridge::context();
                 if ($context['page-template']) {
                     if (defined('WP_DEBUG') && WP_DEBUG) Utility::Log($context['page-template']);
-                    Timber::render($context['page-template'], $context);
+                    TimberBridge::render($context['page-template'], $context);
                 } else {
                     return $template;
                 }

--- a/library/TimberBridge.php
+++ b/library/TimberBridge.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace WDK;
+
+use Timber\Timber;
+
+/**
+ * Compatibility bridge for Timber 1.x and 2.x APIs.
+ */
+class TimberBridge
+{
+    public static function set_locations(array $locations): void
+    {
+        Timber::$locations = $locations;
+    }
+
+    public static function context(): array
+    {
+        return Timber::context();
+    }
+
+    public static function render($templates, array $context): void
+    {
+        Timber::render($templates, $context);
+    }
+
+    public static function get_post()
+    {
+        return method_exists(Timber::class, 'get_post') ? Timber::get_post() : new \Timber\Post();
+    }
+}
+

--- a/tests/e2e/postinterface_search_null_test.php
+++ b/tests/e2e/postinterface_search_null_test.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace {
+    class WP_Post {
+        public int $ID;
+        public function __construct(int $id = 1) { $this->ID = $id; }
+    }
+    class WP_Error {}
+    class WP_Query {
+        public function __construct($args = []) {}
+        public function have_posts() { return false; }
+        public function get_posts() { return []; }
+    }
+    class WP_Comment {}
+
+    function post_type_exists($postType) { return true; }
+    function get_page_by_path($slug, $output, $post_type) { return null; }
+    function sanitize_title($title) { return strtolower(str_replace(' ', '-', $title)); }
+    function get_term_meta($term_id, $key, $single = true) { return 0; }
+    function wp_insert_post($arr, $return_error = false) { return 1; }
+    function wp_update_post($args) { return 1; }
+    function wp_delete_post($id, $force = true) { return true; }
+    function get_post_meta($id, $key = '', $single = false) { return []; }
+    function update_post_meta($id, $key, $value) { return true; }
+    function delete_post_meta($id, $key) { return true; }
+    function is_serialized($v) { return false; }
+    function maybe_unserialize($v) { return $v; }
+    function register_post_meta($a, $b, $c) { return true; }
+    function get_object_taxonomies($post, $output = 'names') { return []; }
+    function get_the_terms($post_id, $taxonomy) { return []; }
+    function get_term($term_id, $taxonomy = null) { return null; }
+    function term_exists($term_name, $taxonomy = null) { return false; }
+    function wp_insert_term($term_name, $taxonomy, $args = []) { return ['term_id' => 1]; }
+    function wp_set_object_terms($post_id, $terms, $taxonomy, $append = false) { return true; }
+    function wp_remove_object_terms($post_id, $terms, $taxonomy) { return true; }
+    function wp_update_term($term_id, $taxonomy, $args = []) { return true; }
+    function get_post_thumbnail_id($post_id) { return 0; }
+    function get_post($id) { return new WP_Post((int)$id); }
+    function set_post_thumbnail($post_id, $attachment_id) { return true; }
+    function wp_get_attachment_metadata($id) { return []; }
+    function get_comments($args = []) { return []; }
+    function wp_count_comments($post_id) { return (object)['approved' => 0]; }
+    function wp_insert_comment($data) { return 1; }
+    function wp_update_comment($args) { return 1; }
+    function wp_trash_comment($id) { return true; }
+    function wp_untrash_comment($id) { return true; }
+    function wp_delete_comment($id, $force = true) { return true; }
+    function update_term_meta($id, $k, $v){ return true; }
+    function delete_term_meta($id, $k){ return true; }
+    function is_wp_error($v){ return false; }
+}
+
+namespace WDK {
+    class Search {
+        public function __construct($provider = null) {}
+        public function search($term, $args) {
+            return (object)['posts' => []];
+        }
+    }
+}
+
+namespace {
+    require_once __DIR__ . '/../../library/PostInterface.php';
+
+    $post = \WDK\PostInterface::post(['search_provider' => 'fake']);
+    if ($post !== null) {
+        fwrite(STDERR, "Expected null when search provider returns no posts.\n");
+        exit(1);
+    }
+
+    echo "PASS: postinterface_search_null_test\n";
+}

--- a/tests/integration/shadow_relationship_test.php
+++ b/tests/integration/shadow_relationship_test.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+class WP_Post {
+    public int $ID;
+    public string $post_type = 'book';
+    public string $post_status = 'publish';
+    public string $post_title = 'Book A';
+    public string $post_name = 'book-a';
+    public function __construct(int $id) { $this->ID = $id; }
+}
+
+class WP_Term {
+    public int $term_id;
+    public string $name = 'Book A';
+    public string $slug = 'book-a';
+    public function __construct(int $id) { $this->term_id = $id; }
+}
+
+class WP_Error {
+    public function get_error_code() { return ''; }
+    public function get_error_data($key = null) { return null; }
+}
+
+$GLOBALS['hooks'] = [];
+$GLOBALS['post_meta'] = [];
+$GLOBALS['term_meta'] = [];
+$GLOBALS['posts'] = [101 => new WP_Post(101)];
+$GLOBALS['next_term_id'] = 200;
+
+function wp_json_encode($value) { return json_encode($value); }
+function add_action($hook, $cb) { $GLOBALS['hooks'][$hook][] = $cb; }
+function get_post($post_id) { return $GLOBALS['posts'][$post_id] ?? null; }
+function get_post_meta($post_id, $key, $single = true) { return $GLOBALS['post_meta'][$post_id][$key] ?? ''; }
+function update_post_meta($post_id, $key, $value) { $GLOBALS['post_meta'][$post_id][$key] = $value; return true; }
+function delete_post_meta($post_id, $key) { unset($GLOBALS['post_meta'][$post_id][$key]); return true; }
+function get_term_meta($term_id, $key, $single = true) { return $GLOBALS['term_meta'][$term_id][$key] ?? ''; }
+function update_term_meta($term_id, $key, $value) { $GLOBALS['term_meta'][$term_id][$key] = $value; return true; }
+function delete_term_meta($term_id, $key) { unset($GLOBALS['term_meta'][$term_id][$key]); return true; }
+function has_term($values, $taxonomy, $post) { return true; }
+function get_term_by($field, $value, $taxonomy) { return new WP_Term((int)$value); }
+function get_posts($args) { return []; }
+function wp_delete_term($term_id, $taxonomy) { return true; }
+function wp_update_term($term_id, $taxonomy, $args) { return ['term_id' => $term_id]; }
+function is_wp_error($thing) { return $thing instanceof WP_Error; }
+function wp_insert_term($name, $taxonomy, $args = []) {
+    $id = ++$GLOBALS['next_term_id'];
+    return ['term_id' => $id];
+}
+function get_term($term_id) { return new WP_Term((int)$term_id); }
+function get_the_terms($post_id, $taxonomy) { return []; }
+
+require_once __DIR__ . '/../../library/Shadow.php';
+
+WDK\Shadow::create_relationship('book', 'book_tax');
+WDK\Shadow::create_relationship('book', 'book_tax'); // duplicate should be ignored
+
+if (count($GLOBALS['hooks']['wp_insert_post'] ?? []) !== 1) {
+    fwrite(STDERR, "Expected duplicate relationship registration protection.\n");
+    exit(1);
+}
+
+$post = $GLOBALS['posts'][101];
+$res = WDK\Shadow::create_shadow_taxonomy_term($post, 'book_tax');
+$termId = (int)$res['term_id'];
+
+if (($GLOBALS['post_meta'][101]['shadow_term_id'] ?? null) !== $termId) {
+    fwrite(STDERR, "Expected post meta shadow_term_id to be linked.\n");
+    exit(1);
+}
+
+if (($GLOBALS['term_meta'][$termId]['shadow_post_id'] ?? null) !== 101) {
+    fwrite(STDERR, "Expected term meta shadow_post_id to be linked.\n");
+    exit(1);
+}
+
+echo "PASS: shadow_relationship_test\n";

--- a/tests/unit/taxonomy_create_term_test.php
+++ b/tests/unit/taxonomy_create_term_test.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+class WpErrorStub {
+    public function get_error_code() { return ''; }
+    public function get_error_data($key = null) { return null; }
+}
+
+$GLOBALS['wdk_opts'] = [];
+$GLOBALS['wdk_terms'] = [];
+
+function get_option($key) { return $GLOBALS['wdk_opts'][$key] ?? false; }
+function update_option($key, $value) { $GLOBALS['wdk_opts'][$key] = $value; return true; }
+function term_exists($term, $taxonomy) {
+    $k = $taxonomy . ':' . $term;
+    return $GLOBALS['wdk_terms'][$k] ?? false;
+}
+function wp_insert_term($term, $taxonomy, $args = []) {
+    $id = count($GLOBALS['wdk_terms']) + 1;
+    $GLOBALS['wdk_terms'][$taxonomy . ':' . $term] = ['term_id' => $id, 'parent' => $args[0] ?? 0];
+    return ['term_id' => $id];
+}
+function add_action($hook, $cb, $priority = 10) { $cb(); return true; }
+
+require_once __DIR__ . '/../../library/Taxonomy.php';
+
+$ok = WDK\Taxonomy::CreateTerm('My Tax', [
+    'Parent' => ['Child A', 'Child B'],
+    'Standalone',
+]);
+
+if ($ok !== true) {
+    fwrite(STDERR, "Expected CreateTerm() to return true for array input.\n");
+    exit(1);
+}
+
+$expected = ['my_tax:Parent', 'my_tax:Child A', 'my_tax:Child B', 'my_tax:Standalone'];
+foreach ($expected as $key) {
+    if (!isset($GLOBALS['wdk_terms'][$key])) {
+        fwrite(STDERR, "Missing expected term: {$key}\n");
+        exit(1);
+    }
+}
+
+echo "PASS: taxonomy_create_term_test\n";


### PR DESCRIPTION
### Motivation
- Provide compatibility with different Timber versions and centralize Timber API calls to avoid API breakage. 
- Harden shadow taxonomy relationship management to avoid duplicate hooks, dangling associations, and failures when posts/terms are missing. 
- Fix small bugs in post creation and post retrieval logic and improve taxonomy term creation handling. 

### Description
- Add `WDK\TimberBridge` as a compatibility wrapper that centralizes `Timber` calls (`set_locations`, `context`, `render`, `get_post`) and update `Template` to use `TimberBridge` instead of direct `Timber` usage.  
- Improve `Shadow` by preventing duplicate relationship registration, validating `WP_Post` objects, tracking associated post via term meta (`shadow_post_id`), and adding `get_associated_post` and `delete_shadow_term_association` improvements to keep term/post associations consistent.  
- Fix `Post::CreatePost` to correctly use the `post_status` meta value (`'post_status' => ! empty($meta['post_status']) ? $meta['post_status'] : 'publish'`).  
- Strengthen `PostInterface::get()` to safely handle search providers that return empty results and return `null` when no post is found.  
- Improve `Taxonomy::CreateTerm` by simplifying array/string handling for nested term creation and replace `array_shift($options)` with `unset($options['hierarchical'])` to avoid unintentionally removing the first option.  
- Make taxonomy handlers more robust by returning boolean in `__isset`, and normalizing term lists in `getAll` to ensure arrays and non-errors are returned.  
- Add `composer.json` test script entry `test` that runs unit, integration, and e2e test files.  
- Add three automated tests: `tests/unit/taxonomy_create_term_test.php`, `tests/integration/shadow_relationship_test.php`, and `tests/e2e/postinterface_search_null_test.php`.  

### Testing
- Added unit test `tests/unit/taxonomy_create_term_test.php` which executes `WDK\Taxonomy::CreateTerm()` with nested arrays and asserts expected terms were created; the test prints `PASS` on success.  
- Added integration test `tests/integration/shadow_relationship_test.php` which verifies duplicate relationship registration is prevented and that `shadow_term_id`/`shadow_post_id` meta are set when creating shadow terms; the test prints `PASS` on success.  
- Added end-to-end test `tests/e2e/postinterface_search_null_test.php` which simulates a search provider returning no posts and asserts `PostInterface::post()` returns `null`; the test prints `PASS` on success.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de80b9e7b083268a65c3d15c1a1c18)